### PR TITLE
Don't show badges if the package is private

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -22,7 +22,7 @@ function inject (username, repo) {
     , crossOrigin: true
     , error   : function (err) { /* probably not an npm package */ }
     , success : function (resp) {
-        if (resp && typeof resp.name == 'string')
+        if (resp && typeof resp.name == 'string' && !resp.private)
           loadFromNpm(resp.name)
       }
   })


### PR DESCRIPTION
Sometimes the repo is not a package. If the `private` field is true, then it most likely is not a package.